### PR TITLE
Add a cargo feature to build for LX7 processors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ mutex-trait = "0.2"
 
 [features]
 lx6 = ["ccompare0", "ccompare1", "ccompare2", "ccount"]
+lx7 = ["ccompare0", "ccompare1", "ccompare2", "ccount"]
 lx106 = ["ccompare0", "ccount"]
 
 # CPU configurations, taken from: https://github.com/espressif/xtensa-overlays

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Low level access to xtensa lx processors. This crate currently supports the foll
 | Feature        | Description                                    |
 |----------------|------------------------------------------------|
 |   `lx6`        | The processors are used in the ESP32 SoC's.    |
+|   `lx7`        | The processors are used in the ESP32-SX SoC's. |
 |   `lx106`      | The processors are used in the ESP8266 SoC's.  |
 
 ## License


### PR DESCRIPTION
Pretty self-explanatory, adds a cargo feature for the LX7 CPU found in the ESP32-S2 and ESP32-S3.

If anybody knows of any additional features for these chips please let me know and I'll add them, this seemed like it though.