### PR TITLE
Add more chip features and cfg away spin for the ESP32-S2 and ESP8266

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,12 @@ links = "xtensa-lx"
 bare-metal = "1.0"
 mutex-trait = "0.2"
 r0 = "1.0"
-spin = "0.9"
+spin = { version = "0.9", optional = true }
 
 [features]
-esp32   = ["ccompare0", "ccompare1", "ccompare2", "ccount"]
+esp32   = ["ccompare0", "ccompare1", "ccompare2", "ccount", "spin"]
+esp32s2 = ["ccompare0", "ccompare1", "ccompare2", "ccount"]
+esp32s3 = ["ccompare0", "ccompare1", "ccompare2", "ccount", "spin"]
 esp8266 = ["ccompare0", "ccount"]
 
 # CPU configurations, taken from: https://github.com/espressif/xtensa-overlays

--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@
 
 Low level access to Xtensa LX processors. This crate currently supports the following CPUs:
 
-| Feature   | Supported CPUs                                       |
-| --------- | ---------------------------------------------------- |
-| `esp32`   | ESP32 (_LX6_), ESP32-S2 (_LX7_) and ESP32-S3 (_LX7_) |
-| `esp8266` | ESP8266 (_LX106_)                                    |
+| Feature   | Supported CPUs    |
+| --------- | ----------------- |
+| `esp32`   | ESP32 (_LX6_)     |
+| `esp32s2` | ESP32-S2 (_LX7_)  |
+| `esp32s3` | ESP32-S3 (_LX7_)  |
+| `esp8266` | ESP8266 (_LX106_) |
 
 ## [Documentation](https://docs.rs/crate/xtensa-lx)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![no_std]
 #![allow(asm_sub_register)]
-#![feature(asm)]
 #![feature(asm_experimental_arch)]
 
 use core::arch::asm;

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -2,15 +2,16 @@
 
 use core::cell::UnsafeCell;
 
-pub extern crate mutex_trait;
-pub use mutex_trait::Mutex;
+pub use mutex_trait::{self, Mutex};
 
 /// A spinlock and critical section section based mutex.
+#[cfg(not(any(feature = "esp32s2", feature = "esp8266")))]
 #[derive(Default)]
 pub struct CriticalSectionSpinLockMutex<T> {
     data: spin::Mutex<T>,
 }
 
+#[cfg(not(any(feature = "esp32s2", feature = "esp8266")))]
 impl<T> CriticalSectionSpinLockMutex<T> {
     /// Create a new mutex
     pub const fn new(data: T) -> Self {
@@ -20,6 +21,7 @@ impl<T> CriticalSectionSpinLockMutex<T> {
     }
 }
 
+#[cfg(not(any(feature = "esp32s2", feature = "esp8266")))]
 impl<T> mutex_trait::Mutex for &'_ CriticalSectionSpinLockMutex<T> {
     type Data = T;
 
@@ -31,6 +33,7 @@ impl<T> mutex_trait::Mutex for &'_ CriticalSectionSpinLockMutex<T> {
 // NOTE A `Mutex` can be used as a channel so the protected data must be `Send`
 // to prevent sending non-Sendable stuff (e.g. access tokens) across different
 // execution contexts (e.g. interrupts)
+#[cfg(not(any(feature = "esp32s2", feature = "esp8266")))]
 unsafe impl<T> Sync for CriticalSectionSpinLockMutex<T> where T: Send {}
 
 /// A Mutex based on critical sections
@@ -68,11 +71,13 @@ impl<T> mutex_trait::Mutex for &'_ CriticalSectionMutex<T> {
 unsafe impl<T> Sync for CriticalSectionMutex<T> where T: Send {}
 
 /// A spinlock based mutex.
+#[cfg(not(any(feature = "esp32s2", feature = "esp8266")))]
 #[derive(Default)]
 pub struct SpinLockMutex<T> {
     data: spin::Mutex<T>,
 }
 
+#[cfg(not(any(feature = "esp32s2", feature = "esp8266")))]
 impl<T> SpinLockMutex<T> {
     /// Create a new mutex
     pub const fn new(data: T) -> Self {
@@ -82,6 +87,7 @@ impl<T> SpinLockMutex<T> {
     }
 }
 
+#[cfg(not(any(feature = "esp32s2", feature = "esp8266")))]
 impl<T> mutex_trait::Mutex for &'_ SpinLockMutex<T> {
     type Data = T;
 
@@ -93,4 +99,5 @@ impl<T> mutex_trait::Mutex for &'_ SpinLockMutex<T> {
 // NOTE A `Mutex` can be used as a channel so the protected data must be `Send`
 // to prevent sending non-Sendable stuff (e.g. access tokens) across different
 // execution contexts (e.g. interrupts)
+#[cfg(not(any(feature = "esp32s2", feature = "esp8266")))]
 unsafe impl<T> Sync for SpinLockMutex<T> where T: Send {}


### PR DESCRIPTION
- Add additional features for `esp32s2` and `esp32s3`, which is now consistent with `xtensa-lx-rt`
- `cfg` away the `spin` dependency as well as `CriticalSectionSpinLockMutex` and `SpinLockMutex` for the ESP32-S2 and ESP8266

Fixes #16