### PR TITLE
Specify a feature to docs.rs to fix building of documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2018"
 # Prevent multiple versions of this crate to be linked together
 links = "xtensa-lx"
 
+[package.metadata.docs.rs]
+features = ["esp32"]
+
 [dependencies]
 bare-metal = "1.0"
 mutex-trait = "0.2"


### PR DESCRIPTION
While checking the [xtensa-lx docs](https://docs.rs/crate/xtensa-lx/latest) I noticed that the most recent build had failed. Referencing the [build log](https://docs.rs/crate/xtensa-lx/0.7.0/builds/544993) made it pretty clear what the issue was.

This just instructs docs.rs to enable the `esp32` feature so that the docs actually build.