### PR TITLE
interrupts.rs: Minor changes when clearing/setting software interrupts.

### DIFF
--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -117,7 +117,7 @@ pub fn get() -> u32 {
 /// Only valid for software interrupts
 #[inline]
 pub unsafe fn set(mask: u32) {
-    asm!("wsr.interrupt {0}", in(reg) mask, options(nostack));
+    asm!("wsr.intset {0}", in(reg) mask, options(nostack));
 }
 
 /// Clear interrupt

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -117,7 +117,12 @@ pub fn get() -> u32 {
 /// Only valid for software interrupts
 #[inline]
 pub unsafe fn set(mask: u32) {
-    asm!("wsr.intset {0}", in(reg) mask, options(nostack));
+    asm!("
+         wsr.intset {0}
+         rsync
+         ",
+         in(reg) mask, options(nostack)
+    );
 }
 
 /// Clear interrupt
@@ -125,7 +130,12 @@ pub unsafe fn set(mask: u32) {
 /// Only valid for software and edge-triggered interrupts
 #[inline]
 pub unsafe fn clear(mask: u32) {
-    asm!("wsr.intclear {0}", in(reg) mask, options(nostack));
+    asm!("
+         wsr.intclear {0}
+         rsync
+         ",
+         in(reg) mask, options(nostack)
+    );
 }
 
 /// Get current interrupt level


### PR DESCRIPTION
Two small changes when clearing and setting software interrupts.  Found just by browsing the code. I don't think anyone is using software interrupts, the change then should have no impact.

1. Use `INTSET` when writing to the `INTERRUPT` register.
2. `rsync` is required after modifying the `INTERRUPT` register, even with `INTSET` or `INTCLEAR`.