### PR TITLE
Make saving and restoring float registers optional

### DIFF
--- a/xtensa-lx-rt/Cargo.toml
+++ b/xtensa-lx-rt/Cargo.toml
@@ -31,3 +31,5 @@ minijinja = "1.0.7"
 esp32   = []
 esp32s2 = []
 esp32s3 = []
+
+float-save-restore = []

--- a/xtensa-lx-rt/src/exception/asm.rs
+++ b/xtensa-lx-rt/src/exception/asm.rs
@@ -166,7 +166,7 @@ unsafe extern "C" fn save_context() {
         rsr     a3, m3
         s32i    a3, sp, +XT_STK_M3
         ",
-        #[cfg(XCHAL_HAVE_DFP_ACCEL)]
+        #[cfg(all(feature = "float-save-restore", XCHAL_HAVE_DFP_ACCEL))]
         "
         // Double Precision Accelerator Option
         rur     a3, f64r_lo 
@@ -176,7 +176,7 @@ unsafe extern "C" fn save_context() {
         rur     a3, f64s   
         s32i    a3, sp, +XT_STK_F64S
         ",
-        #[cfg(XCHAL_HAVE_FP)]
+        #[cfg(all(feature = "float-save-restore", XCHAL_HAVE_FP))]
         "
         // Coprocessor Option
         rur     a3, fcr
@@ -385,7 +385,7 @@ unsafe extern "C" fn restore_context() {
         l32i    a3, sp, +XT_STK_M3
         wsr     a3, m3
         ",
-        #[cfg(XCHAL_HAVE_DFP_ACCEL)]
+        #[cfg(all(feature = "float-save-restore", XCHAL_HAVE_DFP_ACCEL))]
         "
         // Double Precision Accelerator Option
         l32i    a3, sp, +XT_STK_F64R_LO
@@ -395,7 +395,7 @@ unsafe extern "C" fn restore_context() {
         l32i    a3, sp, +XT_STK_F64S
         wur     a3, f64s
         ",
-        #[cfg(XCHAL_HAVE_FP)]
+        #[cfg(all(feature = "float-save-restore", XCHAL_HAVE_FP))]
         "
         // Coprocessor Option
         l32i    a3, sp, +XT_STK_FCR

--- a/xtensa-lx-rt/src/exception/asm.rs
+++ b/xtensa-lx-rt/src/exception/asm.rs
@@ -122,6 +122,13 @@ unsafe extern "C" fn save_context() {
         rsr     a3,  SAR
         s32i    a3,  sp, +XT_STK_SAR
         ",
+        #[cfg(all(XCHAL_HAVE_CP, not(feature = "float-save-restore")))]
+        "
+        /* Disable coprocessor, any use of floats in ISRs will cause an exception unless float-save-restore feature is enabled */
+        movi    a3,  0
+        wsr     a3,  CPENABLE
+        rsync
+        ",
         #[cfg(XCHAL_HAVE_LOOPS)]
         "
         // Loop Option
@@ -418,6 +425,13 @@ unsafe extern "C" fn restore_context() {
         lsi     f13, sp, +XT_STK_F13
         lsi     f14, sp, +XT_STK_F14
         lsi     f15, sp, +XT_STK_F15
+        ",
+        #[cfg(all(XCHAL_HAVE_CP, not(feature = "float-save-restore")))]
+        "
+        /* Re-enable coprocessor(s) after ISR */
+        movi    a3,  8 /* XCHAL_CP_MAXCFG */
+        wsr     a3,  CPENABLE
+        rsync
         ",
         "
         // general registers

--- a/xtensa-lx-rt/src/exception/context.rs
+++ b/xtensa-lx-rt/src/exception/context.rs
@@ -43,26 +43,47 @@ pub struct Context {
     pub M1: u32,
     pub M2: u32,
     pub M3: u32,
+    #[cfg(all(feature = "float-save-restore", XCHAL_HAVE_DFP_ACCEL))]
     pub F64R_LO: u32,
+    #[cfg(all(feature = "float-save-restore", XCHAL_HAVE_DFP_ACCEL))]
     pub F64R_HI: u32,
+    #[cfg(all(feature = "float-save-restore", XCHAL_HAVE_DFP_ACCEL))]
     pub F64S: u32,
+    #[cfg(all(feature = "float-save-restore", XCHAL_HAVE_FP))]
     pub FCR: u32,
+    #[cfg(all(feature = "float-save-restore", XCHAL_HAVE_FP))]
     pub FSR: u32,
+    #[cfg(all(feature = "float-save-restore", XCHAL_HAVE_FP))]
     pub F0: u32,
+    #[cfg(all(feature = "float-save-restore", XCHAL_HAVE_FP))]
     pub F1: u32,
+    #[cfg(all(feature = "float-save-restore", XCHAL_HAVE_FP))]
     pub F2: u32,
+    #[cfg(all(feature = "float-save-restore", XCHAL_HAVE_FP))]
     pub F3: u32,
+    #[cfg(all(feature = "float-save-restore", XCHAL_HAVE_FP))]
     pub F4: u32,
+    #[cfg(all(feature = "float-save-restore", XCHAL_HAVE_FP))]
     pub F5: u32,
+    #[cfg(all(feature = "float-save-restore", XCHAL_HAVE_FP))]
     pub F6: u32,
+    #[cfg(all(feature = "float-save-restore", XCHAL_HAVE_FP))]
     pub F7: u32,
+    #[cfg(all(feature = "float-save-restore", XCHAL_HAVE_FP))]
     pub F8: u32,
+    #[cfg(all(feature = "float-save-restore", XCHAL_HAVE_FP))]
     pub F9: u32,
+    #[cfg(all(feature = "float-save-restore", XCHAL_HAVE_FP))]
     pub F10: u32,
+    #[cfg(all(feature = "float-save-restore", XCHAL_HAVE_FP))]
     pub F11: u32,
+    #[cfg(all(feature = "float-save-restore", XCHAL_HAVE_FP))]
     pub F12: u32,
+    #[cfg(all(feature = "float-save-restore", XCHAL_HAVE_FP))]
     pub F13: u32,
+    #[cfg(all(feature = "float-save-restore", XCHAL_HAVE_FP))]
     pub F14: u32,
+    #[cfg(all(feature = "float-save-restore", XCHAL_HAVE_FP))]
     pub F15: u32,
 }
 

--- a/xtensa-lx/Cargo.toml
+++ b/xtensa-lx/Cargo.toml
@@ -36,3 +36,5 @@ ccompare3 = []
 
 # ccount
 ccount = []
+
+float-save-restore = []


### PR DESCRIPTION
Closes https://github.com/esp-rs/xtensa-lx/issues/27

I once again tried it out on esp-wifi, but sadly it didn't seem to make much difference. I guess there is a bottleneck somewhere else for Xtensa.