### PR TITLE
Add missing `#[doc(hidden)]` attribute

### DIFF
--- a/xtensa-lx-rt/procmacros/src/lib.rs
+++ b/xtensa-lx-rt/procmacros/src/lib.rs
@@ -377,6 +377,7 @@ pub fn interrupt(args: TokenStream, input: TokenStream) -> TokenStream {
                 )
             }
 
+            #[doc(hidden)]
             #[allow(clippy::inline_always)]
             #[inline(always)]
             #f


### PR DESCRIPTION
This is a partial fix for https://github.com/esp-rs/esp-hal/issues/1233